### PR TITLE
added coregister dropdown list displays all scans from the patient

### DIFF
--- a/src/wezel/actions/transform.py
+++ b/src/wezel/actions/transform.py
@@ -185,7 +185,7 @@ class CoregisterTo(wezel.Action):
 
     def run(self, app):
         for series in app.selected('Series'):
-            seriesList = series.parent().children()
+            seriesList = series.parent().parent().series()
             seriesLabels = [s.instance().SeriesDescription for s in seriesList]
             input = wezel.widgets.UserInput(
                 {"label":"Coregister to which fixed series?", "type":"dropdownlist", "list": seriesLabels, 'value':0},


### PR DESCRIPTION
The dropdown list of **transform -> Coregister to..** displays all scans from the patient (not only the ones of the same study)